### PR TITLE
Setter aktørId og identitetsnummer som påbudt

### DIFF
--- a/src/main/kotlin/no/nav/helse/prosessering/v1/søknad/Barn.kt
+++ b/src/main/kotlin/no/nav/helse/prosessering/v1/søknad/Barn.kt
@@ -7,8 +7,8 @@ import java.util.*
 
 data class Barn (
     val navn: String,
-    val aktørId: String?,
-    var identitetsnummer: String?,
+    val aktørId: String,
+    var identitetsnummer: String,
     val tidspunktForAleneomsorg: TidspunktForAleneomsorg,
     val dato: LocalDate? = null
 ) {

--- a/src/test/kotlin/no/nav/helse/SøknadUtils.kt
+++ b/src/test/kotlin/no/nav/helse/SøknadUtils.kt
@@ -36,7 +36,7 @@ object SøknadUtils {
         barn = Barn(
             navn = "Ole Dole",
             identitetsnummer = "29076523302",
-            aktørId = null,
+            aktørId = "12345",
             tidspunktForAleneomsorg = TidspunktForAleneomsorg.SISTE_2_ÅRENE,
             dato = LocalDate.now().minusMonths(4)
         ),


### PR DESCRIPTION
Bruker får kun valgt barn vi får fra oppslag, så aktørId og identitetsnummer kan være påbudt. 