### PR TITLE
Legger til k9-brukerdialog-api som producer og fikser ISOLATION_LEVEL_CONFIG

### DIFF
--- a/nais/topics.yml
+++ b/nais/topics.yml
@@ -19,6 +19,9 @@ spec:
       application: omsorgsdager-aleneomsorg-api
       access: readwrite
     - team: dusseldorf
+      application: k9-brukerdialog-api
+      access: write
+    - team: dusseldorf
       application: omsorgsdager-aleneomsorg-prosessering
       access: read
 

--- a/src/main/kotlin/no/nav/helse/kafka/KafkaConfig.kt
+++ b/src/main/kotlin/no/nav/helse/kafka/KafkaConfig.kt
@@ -28,6 +28,7 @@ internal class KafkaConfig(
         put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
         put(DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, LogAndFailExceptionHandler::class.java)
         put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset)
+        put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed")
         if(trustStore == null || keyStore == null) medCredentials(Pair("srvkafkaclient", "kafkaclient")) //For å skille mellom test/miljø
         medTrustStore(trustStore)
         medKeyStore(keyStore)


### PR DESCRIPTION
Setter ISOLATION_LEVEL_CONFIG til "read_commited" slik at den kun leser meldinger som har blitt commited.

"Controls how to read messages written transactionally. If set to <code>read_committed</code>, consumer.poll() will only return transactional messages which have been committed. If set to <code>read_uncommitted</code> (the default), consumer.poll() will return all messages, even transactional messages which have been aborted. Non-transactional messages will be returned unconditionally in either mode. <p>Messages will always be returned in offset order. Hence, in  <code>read_committed</code> mode, consumer.poll() will only return messages up to the last stable offset (LSO), which is the one less than the offset of the first open transaction. In particular any messages appearing after messages belonging to ongoing transactions will be withheld until the relevant transaction has been completed. As a result, <code>read_committed</code> consumers will not be able to read up to the high watermark when there are in flight transactions.</p><p> Further, when in <code>read_committed</code> the seekToEnd method will return the LSO";